### PR TITLE
Add name attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "tmpreaper"
 maintainer       "CustomInk, LLC"
 maintainer_email "svargo@customink.com"
 license          "All rights reserved"


### PR DESCRIPTION
As of berkshelf 3, every cookbook should have an explicit name attribute. See https://github.com/berkshelf/berkshelf/issues/1197 for details.
