### PR TITLE
Added a name attribute to the metadata (required by Berkshelf 3).

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,10 @@
-maintainer       "CustomInk, LLC"
+maintainer       "CustomInk, LLC" 
 maintainer_email "svargo@customink.com"
 license          "All rights reserved"
 description      "Installs/Configures tmpreaper"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.3"
+name             "tmpreaper"
 
 recipe "tmpreaper", "Main tmpreaper configuration"
 recipe "tmpreaper::schedule", "Adds cron job for tmpreaper"


### PR DESCRIPTION
Hi:

Thanks so much for your tmpreaper cookbook; it has been super useful for us! We had to add a "name" attribute to get the cookbook to work with Berkshelf 3.x; would it be possible for you to merge in this pull request?

Thanks again,
Greg
