### PR TITLE
drop local knife config

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -1,2 +1,0 @@
-cache_type 'BasicFile'
-cache_options(:path => "#{ENV['HOME']}/.chef/checksums")


### PR DESCRIPTION
confuses knife cookbook upload when it finds `.chef/knife.rb` from current dir